### PR TITLE
Cache `uidNumber` call

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,11 +3,13 @@ var gutil = require('gulp-util');
 var through = require('through2');
 var uidNumber = require('uid-number');
 var defaultMode = 511 & (~process.umask()); // 511 = 0777
+var cachedUid;
+var cachedGid;
 
 module.exports = function (user, group) {
 	var firstFile = true;
-	var finalUid = typeof user === 'number' ? user : null;
-	var finalGid = typeof group === 'number' ? group : null;
+	var finalUid = typeof cachedUid === 'number' ? cachedUid : typeof user === 'number' ? user : null;
+	var finalGid = typeof cachedGid === 'number' ? cachedGid : typeof group === 'number' ? group : null;
 
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {
@@ -18,21 +20,21 @@ module.exports = function (user, group) {
 		file.stat = file.stat || {};
 		file.stat.mode = file.stat.mode || defaultMode;
 
-		var finish = function () {
+		function finish() {
 			file.stat.uid = finalUid != null ? finalUid : file.stat.uid;
 			file.stat.gid = finalGid != null ? finalGid : file.stat.gid;
 			cb(null, file);
-		};
+		}
 
-		if (firstFile && typeof user === 'string') {
+		if (firstFile && typeof user === 'string' && finalUid === null && finalGid === null) {
 			uidNumber(user, group, function (err, uid, gid) {
 				if (err) {
 					cb(new gutil.PluginError('gulp-chmod', err, {fileName: file.path}));
 					return;
 				}
 
-				finalUid = uid;
-				finalGid = gid;
+				cachedUid = finalUid = uid;
+				cachedGid = finalGid = gid;
 
 				finish();
 			});


### PR DESCRIPTION
Tried logging inside `uidNumber()` and it only ran once using `gulp.watch()` with multiple files and repeatedly saving them.

Fixes #1.
